### PR TITLE
Delay secondary subtitle refreshing (for #9)

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -1,6 +1,8 @@
 // wraper console.xxx() to add prefix
 const prefix = 'NflxMultiSubs>';
 const console = {
+  // debug: (...args) => window.console.log(prefix, ...args),
+  debug: (...args) => true,
   log: (...args) => window.console.log(prefix, ...args),
   warn: (...args) => window.console.warn(prefix, ...args),
   error: (...args) => window.console.error(prefix, ...args),


### PR DESCRIPTION
Since this extension has generally faster refreshing rate than netflix original renderer, we delay (with a timeout) the refreshing **until** corresponding main subtitle refreshes.

For #9. 目前實作到改善主次字幕在render上的效能差異（讓本套件去等原生 renderer），
尚未實作不同語言字幕的時間軸對齊。
先創立pull request 以利即時 review 這個部分。