### PR TITLE
Fix menu reverse issue and filter NoneTrack option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "NflxMultiSubs",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -351,6 +351,13 @@ class SubtitleFactory {
     return this._buildTextBased(track, lang, bcp47);
   }
 
+  static isNoneTrack(track) {
+    // new_track_id example"T:1:0;1;zh-Hant;1;1;"
+    // the last bit is 1 for NoneTrack text tracks
+    const isNoneTrackBit = track.new_track_id.split(';')[4];
+    return isNoneTrackBit === '1';
+  }
+
   static _buildImageBased(track, lang, bcp47) {
     const maxHeight = Math.max(...Object.values(track.ttDownloadables).map(d => d.height));
     const d = Object.values(track.ttDownloadables).find(d => d.height === maxHeight);
@@ -378,6 +385,7 @@ const buildSubtitleList = textTracks => {
   // sorted by language in alphabetical order (to align with official UI)
   const subs = textTracks
     .filter(t => !t.isNoneTrack)
+    .filter(t => !SubtitleFactory.isNoneTrack(t))
     .map(t => SubtitleFactory.build(t));
   return subs.concat(dummy);
 };

--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -1054,7 +1054,7 @@ class NflxMultiSubsManager {
             const defaultAudioTrack = manifest.audio_tracks.find(t => t.id == defaultAudioId);
             const defaultAudioLanguage = defaultAudioTrack.language;
             console.log(`Default audio track language: ${defaultAudioLanguage}`);
-            const autoSubtitleId = gSubtitles.reverse().findIndex(t => t.bcp47 == defaultAudioLanguage);
+            const autoSubtitleId = gSubtitles.findIndex(t => t.bcp47 == defaultAudioLanguage);
             if (autoSubtitleId >= 0) {
               console.log(`Subtitle #${autoSubtitleId} auto-enabled to match audio`);
               activateSubtitle(autoSubtitleId);


### PR DESCRIPTION
### Issue Description
When the auto-select failed to select the secondary subtitle, the menu will be reversed when users click on one of the options. Because the `reverse()` was added for the fake NoneTrack subtitle, I also filter it from the menu.
### Change
1. Update version in package-lock.json
2. Filter the fake NoneTrack from the secondary subtitles menu
3. Fix the reverse issue