### PR TITLE
Fix for Netflix redesign

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,6 +2,7 @@
   "name": "NflxMultiSubs (Netflix Multi. Subtitles)",
   "manifest_version": 2,
   "author": "Dan Chen",
+  "version": "1.0",
 
   "permissions": [
     "storage",

--- a/src/nflxmultisubs.js
+++ b/src/nflxmultisubs.js
@@ -450,7 +450,7 @@ class SubtitleMenu {
 const isPopupMenuElement = node => {
   return (
     node.nodeName.toLowerCase() === 'div' &&
-    node.classList.contains('audio-subtitle-controller')
+    node.querySelector('div[data-uia="selector-audio-subtitle"]')
   );
 };
 
@@ -824,7 +824,7 @@ class RendererLoop {
   // @returns {boolean} Successed?
   _appendSubtitleWrapper() {
     if (!this.subtitleWrapperElem || !this.subtitleWrapperElem.parentNode) {
-      const playerContainerElem = document.querySelector('.nf-player-container');
+      const playerContainerElem = document.querySelector('div[data-uia="video-canvas"]');
       if (!playerContainerElem) return false;
       this.subtitleWrapperElem = buildSecondarySubtitleElement(gRenderOptions);
       playerContainerElem.appendChild(this.subtitleWrapperElem);


### PR DESCRIPTION
Recent video player redesign broke the extension. The secondary sub list was no longer added to the sub popup.

@makfc fixed it. 🥳

@dannvix suggest to merge and update the Chrome store release asap.

EDIT: This PR is out of date, but I'm keeping it open so the owner might see it. If you're a user of this extension, you can install the updated version from my [fork](https://github.com/gmertes/NflxMultiSubs/) that contains the full fix for the redesign and addition bug fixes.